### PR TITLE
use sqlite by default

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
 DEBUG=on
 SECRET_KEY=django-insecure-nm#!8%z$hc0wwi#m_*l9l)=m*6gs4&o_^-e5b5vj*k05&yaqc1
-DATABASE_URL=psql://decompme:decompme@127.0.0.1:5432/decompme
+DATABASE_URL=sqlite:///dev.db
 API_BASE=http://127.0.0.1:8000/api

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build
 .snowpack
 backend/local_files/
 postgres/
+*.db

--- a/README.md
+++ b/README.md
@@ -5,18 +5,15 @@ A collaborative decompilation and reverse engineering platform
 https://docs.google.com/document/d/19SjmFkjnxYEq5CXsuwiCcXetx07Z04b0QWRgRq_WjzM/edit?usp=sharing
 
 ## Contributing
-PostgreSQL and Python are the main runtime dependencies required. Credentials for a test environment can be found in the main app settings file.
 
 ### Directory structure
 `frontend/` contains the website sourcecode
 
 `backend/` contains the Django project
 
+`.env` contains configuration
+
 ### Backend
-The backend requires a running PostgreSQL database.
-
-Please create a user named `decompme` who has permissions to work with a database called `decompme`.
-
 A virtual environment like virtualenv is recommended for handling python dependencies.
 You might have to use python3 instead of python for the following commands.
 ```shell


### PR DESCRIPTION
Configures the default `.env` to use SQLite by default, meaning a postgresql server is no longer required.

Also removes postgres from requirements.txt, as its only needed in production (and even then its a choice on behalf of whoever's hosting as to which db they use).

Resolves #28.