### PR TITLE
Support .late_rodata in scratch creation

### DIFF
--- a/backend/coreapp/compiler_wrapper.py
+++ b/backend/coreapp/compiler_wrapper.py
@@ -12,11 +12,16 @@ import subprocess
 logger = logging.getLogger(__name__)
 
 ASM_PRELUDE: str = """
+.macro .late_rodata
+    .section .rodata
+.endm
+
 .macro glabel label
     .global \label
     .type \label, @function
     \label:
 .endm
+
 .set noat
 .set noreorder
 .set gp=64

--- a/backend/coreapp/tests.py
+++ b/backend/coreapp/tests.py
@@ -1,3 +1,35 @@
-from django.test import TestCase
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
 
-# Create your tests here.
+from coreapp.models import Scratch
+
+class ScratchCreationTests(APITestCase):
+    scratch_url: str
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.scratch_url = reverse('scratch')
+
+    def test_accept_late_rodata(self):
+        """
+        Ensure that .late_rodata (used in ASM_PROCESSOR) is accepted during scratch creation.
+        """
+        scratch_dict = {
+            'arch': 'mips',
+            'context': '',
+            'target_asm':
+""".late_rodata
+glabel D_8092C224
+/* 000014 8092C224 3DCCCCCD */ .float 0.1
+
+.text
+glabel func_80929D04
+jr $ra
+nop"""
+        }
+
+        response = self.client.post(self.scratch_url, scratch_dict)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(Scratch.objects.count(), 1)


### PR DESCRIPTION
I added a test for this as well, which I'll continue to do for new fixes and features. You run the tests from the backend dir by simply doing `python3 manage.py test`. (Fixes #98)