### PR TITLE
Add /scratch/<slug>/compile test

### DIFF
--- a/backend/coreapp/asm_diff_wrapper.py
+++ b/backend/coreapp/asm_diff_wrapper.py
@@ -32,6 +32,7 @@ class AsmDifferWrapper:
             skip_lines=0,
             compress=None,
             show_branches=True,
+            show_line_numbers=False,
             stop_jrra=False,
             ignore_large_imms=False,
             ignore_addr_diffs=False,

--- a/backend/coreapp/asm_diff_wrapper.py
+++ b/backend/coreapp/asm_diff_wrapper.py
@@ -27,7 +27,7 @@ class AsmDifferWrapper:
             max_function_size_bytes=MAX_FUNC_SIZE_LINES * 4,
             # Display options
             formatter=HtmlFormatter(),
-            threeway=False,
+            threeway=None,
             base_shift=0,
             skip_lines=0,
             compress=None,

--- a/backend/coreapp/tests.py
+++ b/backend/coreapp/tests.py
@@ -1,12 +1,11 @@
 from coreapp.compiler_wrapper import CompilerWrapper
-from django.test.testcases import TestCase
 from django.urls import reverse
 from django.contrib.auth.models import User
 from rest_framework import status
 from rest_framework.test import APITestCase
 import responses
 
-from .models import Scratch, Profile
+from .models import Compilation, Scratch, Profile
 from .github import GitHubUser
 
 class ScratchCreationTests(APITestCase):
@@ -39,7 +38,43 @@ nop"""
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(Scratch.objects.count(), 1)
 
-class CompilationTests(TestCase):
+class CompilationTests(APITestCase):
+    scratch_url: str
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.scratch_url = reverse('scratch')
+
+    def test_simple_compilation(self):
+        """
+        Ensure that we can run a simple compilation via the api
+        """
+        scratch_dict = {
+            'arch': 'mips',
+            'context': '',
+            'target_asm': 'glabel func_80929D04\njr $ra\nnop'
+        }
+
+        # Test that we can create a scratch
+        response = self.client.post(self.scratch_url, scratch_dict)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(Scratch.objects.count(), 1)
+
+        slug = response.data["scratch"]["slug"]
+
+        compile_dict = {
+            'slug': slug,
+            'compiler': 'gcc2.8.1',
+            'cc_opts': '-mips2 -O2',
+            'source_code': 'int add(int a, int b){\nreturn a + b;\n}\n'
+        }
+
+        # Test that we can compile a scratch
+        response = self.client.post(f"{self.scratch_url}/{slug}/compile", compile_dict)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(Compilation.objects.count(), 1)
+
     def test_ido_line_endings(self):
         """
         Ensure that compilations with \r\n line endings succeed

--- a/backend/coreapp/tests.py
+++ b/backend/coreapp/tests.py
@@ -61,7 +61,7 @@ class CompilationTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(Scratch.objects.count(), 1)
 
-        slug = response.data["scratch"]["slug"]
+        slug = response.json()["scratch"]["slug"]
 
         compile_dict = {
             'slug': slug,

--- a/backend/coreapp/tests.py
+++ b/backend/coreapp/tests.py
@@ -9,13 +9,6 @@ from .models import Compilation, Scratch, Profile
 from .github import GitHubUser
 
 class ScratchCreationTests(APITestCase):
-    scratch_url: str
-
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.scratch_url = reverse('scratch')
-
     def test_accept_late_rodata(self):
         """
         Ensure that .late_rodata (used in ASM_PROCESSOR) is accepted during scratch creation.
@@ -34,18 +27,11 @@ jr $ra
 nop"""
         }
 
-        response = self.client.post(self.scratch_url, scratch_dict)
+        response = self.client.post(reverse('scratch'), scratch_dict)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(Scratch.objects.count(), 1)
 
 class CompilationTests(APITestCase):
-    scratch_url: str
-
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.scratch_url = reverse('scratch')
-
     def test_simple_compilation(self):
         """
         Ensure that we can run a simple compilation via the api
@@ -57,7 +43,7 @@ class CompilationTests(APITestCase):
         }
 
         # Test that we can create a scratch
-        response = self.client.post(self.scratch_url, scratch_dict)
+        response = self.client.post(reverse('scratch'), scratch_dict)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(Scratch.objects.count(), 1)
 
@@ -71,7 +57,7 @@ class CompilationTests(APITestCase):
         }
 
         # Test that we can compile a scratch
-        response = self.client.post(f"{self.scratch_url}/{slug}/compile", compile_dict)
+        response = self.client.post(reverse("compile_scratch", kwargs={"slug": slug}), compile_dict)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Compilation.objects.count(), 1)
 


### PR DESCRIPTION
Added a test that creates a scratch and calls compile via the API. This will catch future integration issues with asm-differ.