### PR TITLE
Fix duplicated line numbers by using new version of `asm_differ`

### DIFF
--- a/backend/asm_differ/.gitrepo
+++ b/backend/asm_differ/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/simonlindholm/asm-differ
 	branch = main
-	commit = d6474d7188abf0eb6eb78f2e0967b4feb303430d
-	parent = a519a826ce2d5ff1a5a4e57e821849476bfe4e91
+	commit = 55bba23ad53dea059db783bb5598bc0c299863e6
+	parent = 470362b680359d8ab3285f86a3a55cbaa91e199c
 	method = merge
 	cmdver = 0.4.3

--- a/backend/asm_differ/diff.py
+++ b/backend/asm_differ/diff.py
@@ -120,7 +120,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "-c",
         "--source",
-        dest="source",
+        dest="show_source",
         action="store_true",
         help="Show source code (if possible). Only works with -o or -e.",
     )
@@ -380,7 +380,6 @@ class Config:
     # Build/objdump options
     diff_obj: bool
     make: bool
-    source: bool
     source_old_binutils: bool
     inlines: bool
     max_function_size_lines: int
@@ -394,6 +393,7 @@ class Config:
     compress: Optional[Compress]
     show_branches: bool
     show_line_numbers: bool
+    show_source: bool
     stop_jrra: bool
     ignore_large_imms: bool
     ignore_addr_diffs: bool
@@ -462,7 +462,6 @@ def create_config(args: argparse.Namespace, project: ProjectSettings) -> Config:
         # Build/objdump options
         diff_obj=args.diff_obj,
         make=args.make,
-        source=args.source or args.source_old_binutils,
         source_old_binutils=args.source_old_binutils,
         inlines=args.inlines,
         max_function_size_lines=args.max_lines,
@@ -477,6 +476,7 @@ def create_config(args: argparse.Namespace, project: ProjectSettings) -> Config:
         compress=compress,
         show_branches=args.show_branches,
         show_line_numbers=show_line_numbers,
+        show_source=args.show_source or args.source_old_binutils,
         stop_jrra=args.stop_jrra,
         ignore_large_imms=args.ignore_large_imms,
         ignore_addr_diffs=args.ignore_addr_diffs,
@@ -965,10 +965,10 @@ def serialize_data_references(references: List[Tuple[int, int, str]]) -> str:
 def maybe_get_objdump_source_flags(config: Config) -> List[str]:
     flags = []
 
-    if config.show_line_numbers or config.source:
+    if config.show_line_numbers or config.show_source:
         flags.append("--line-numbers")
 
-    if config.source:
+    if config.show_source:
         flags.append("--source")
 
         if not config.source_old_binutils:
@@ -1310,7 +1310,7 @@ def dump_binary(
         end_addr = eval_int(end, "End address must be an integer expression.")
     else:
         end_addr = start_addr + config.max_function_size_bytes
-    objdump_flags = ["-Dz", "-bbinary", "-EB"]
+    objdump_flags = ["-Dz", "-bbinary"] + ["-EB" if config.arch.big_endian else "-EL"]
     flags1 = [
         f"--start-address={start_addr + config.base_shift}",
         f"--stop-address={end_addr + config.base_shift}",
@@ -1421,6 +1421,7 @@ class ArchSettings:
     arch_flags: List[str] = field(default_factory=list)
     branch_likely_instructions: Set[str] = field(default_factory=set)
     difference_normalizer: Type[DifferenceNormalizer] = DifferenceNormalizer
+    big_endian: Optional[bool] = True
 
 
 MIPS_BRANCH_LIKELY_INSTRUCTIONS = {
@@ -1544,6 +1545,8 @@ MIPS_SETTINGS = ArchSettings(
     instructions_with_address_immediates=MIPS_BRANCH_INSTRUCTIONS.union({"jal", "j"}),
 )
 
+MIPSEL_SETTINGS = replace(MIPS_SETTINGS, name="mipsel", big_endian=False)
+
 ARM32_SETTINGS = ArchSettings(
     name="arm32",
     re_int=re.compile(r"[0-9]+"),
@@ -1593,6 +1596,7 @@ PPC_SETTINGS = ArchSettings(
 
 ARCH_SETTINGS = [
     MIPS_SETTINGS,
+    MIPSEL_SETTINGS,
     ARM32_SETTINGS,
     AARCH64_SETTINGS,
     PPC_SETTINGS,
@@ -1744,7 +1748,10 @@ def process(dump: str, config: Config) -> List[Line]:
         row = lines[i]
         i += 1
 
-        if config.diff_obj and (">:" in row or not row):
+        if not row:
+            continue
+
+        if re.match(r"^[0-9a-f]+ <.*>:$", row):
             continue
 
         if row.startswith("DATAREF"):
@@ -1767,35 +1774,15 @@ def process(dump: str, config: Config) -> List[Line]:
             )
             break
 
-        # This regex is conservative, and assumes the file path does not contain "weird"
-        # characters like colons, tabs, or angle brackets.
-        if (
-            config.show_line_numbers
-            and row
-            and re.match(
+        if not re.match(r"^ +[0-9a-f]+:\t", row):
+            # This regex is conservative, and assumes the file path does not contain "weird"
+            # characters like colons, tabs, or angle brackets.
+            if re.match(
                 r"^[^ \t<>:][^\t<>:]*:[0-9]+( \(discriminator [0-9]+\))?$", row
-            )
-        ):
-            source_filename, _, tail = row.rpartition(":")
-            source_line_num = int(tail.partition(" ")[0])
-            if config.source:
-                source_lines.append(row)
-            continue
-
-        if config.source and not config.source_old_binutils and (row and row[0] != " "):
+            ):
+                source_filename, _, tail = row.rpartition(":")
+                source_line_num = int(tail.partition(" ")[0])
             source_lines.append(row)
-            continue
-
-        if (
-            config.source
-            and config.source_old_binutils
-            and (row and not re.match(r"^ +[0-9a-f]+:\t", row))
-        ):
-            source_lines.append(row)
-            continue
-
-        # `objdump --line-numbers` includes function markers, even without `--source`
-        if config.show_line_numbers and row and re.match(r"^[^ \t]+\(\):$", row):
             continue
 
         m_comment = re.search(arch.re_comment, row)
@@ -2130,7 +2117,7 @@ class Diff:
 
 
 def do_diff(lines1: List[Line], lines2: List[Line], config: Config) -> Diff:
-    if config.source:
+    if config.show_source:
         import cxxfilt
     arch = config.arch
     fmt = config.formatter
@@ -2287,7 +2274,7 @@ def do_diff(lines1: List[Line], lines2: List[Line], config: Config) -> Diff:
             out1 = Text()
             out2 = out2.reformat(line_color2)
 
-        if config.source and line2 and line2.comment:
+        if config.show_source and line2 and line2.comment:
             out2 += f" {line2.comment}"
 
         def format_part(
@@ -2314,7 +2301,7 @@ def do_diff(lines1: List[Line], lines2: List[Line], config: Config) -> Diff:
         part1 = format_part(out1, line1, line_color1, bts1, sc5)
         part2 = format_part(out2, line2, line_color2, bts2, sc6)
 
-        if line2:
+        if config.show_source and line2:
             for source_line in line2.source_lines:
                 line_format = BasicFormat.SOURCE_OTHER
                 if config.source_old_binutils:
@@ -2738,7 +2725,7 @@ def main() -> None:
         except ModuleNotFoundError as e:
             fail(MISSING_PREREQUISITES.format(e.name))
 
-    if config.source:
+    if config.show_source:
         try:
             import cxxfilt
         except ModuleNotFoundError as e:

--- a/backend/coreapp/asm_diff_wrapper.py
+++ b/backend/coreapp/asm_diff_wrapper.py
@@ -21,8 +21,7 @@ class AsmDifferWrapper:
             # Build/objdump options
             diff_obj=True,
             make=False,
-            source=False,
-            source_old_binutils=False,
+            source_old_binutils=True,
             inlines=False,
             max_function_size_lines=MAX_FUNC_SIZE_LINES,
             max_function_size_bytes=MAX_FUNC_SIZE_LINES * 4,
@@ -33,7 +32,8 @@ class AsmDifferWrapper:
             skip_lines=0,
             compress=None,
             show_branches=True,
-            show_line_numbers=True,
+            show_line_numbers=False,
+            show_source=False,
             stop_jrra=False,
             ignore_large_imms=False,
             ignore_addr_diffs=False,
@@ -42,7 +42,12 @@ class AsmDifferWrapper:
 
     @staticmethod
     def run_objdump(target_data: bytes, config: asm_differ.Config) -> Optional[str]:
-        flags = ["-drzl"]
+        flags = [
+            "--disassemble",
+            "--disassemble-zeroes",
+            "--line-numbers",
+            "--reloc",
+        ]
 
         with Sandbox() as sandbox:
             target_path = sandbox.path / "out.s"
@@ -58,6 +63,7 @@ class AsmDifferWrapper:
                 )
             except subprocess.CalledProcessError as e:
                 logger.error(e)
+                logger.error(e.stderr)
                 return None
 
         out = objdump_proc.stdout

--- a/frontend/src/diff/Diff.module.css
+++ b/frontend/src/diff/Diff.module.css
@@ -33,6 +33,7 @@
 .source_filename { font-weight: bold }
 .source_function { font-weight: bold; text-decoration: underline }
 .source_other { font-style: italic }
+.source_line_num { font-style: italic }
 .rotation0 { color: magenta}
 .rotation1 { color: cyan }
 .rotation2 { color: rgb(0, 212, 0) }


### PR DESCRIPTION
Pretty small change. Imported fixes from `asm_differ`, then disabled `show_line_numbers` & `show_source` in the config.

Result screenshot: 
![2021-09-21-183021_805x225_scrot](https://user-images.githubusercontent.com/113075/134256230-18fecde3-bef2-460b-8df7-f1c4f5ccb45a.png)
